### PR TITLE
WIP: Windows support

### DIFF
--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -2,7 +2,7 @@ from base64 import b64decode, b64encode
 import json
 import os.path
 import platform
-import pysodium
+from nacl import bindings as pysodium
 import socket
 from pathlib import Path
 import win32file

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -2,10 +2,14 @@ from base64 import b64decode, b64encode
 import json
 import os.path
 import platform
-from nacl import bindings as pysodium
 import socket
 from pathlib import Path
-import win32file
+if platform.system() == "Windows":
+    from nacl import bindings as pysodium
+    import win32file
+else:
+    import pysodium
+
 
 BUFF_SIZE = 1024 * 1024
 DEFAULT_SOCKET_TIMEOUT = 60

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -108,7 +108,8 @@ class ProtocolError(Exception):
 
 class WinSock:
     """ A basic socket wrapper for Windows named pipes """
-    def __init__(self, desired_access, creation_disposition, share_mode=0, security_attributes=None, flags_and_attributes=0, input_nullok=None):
+    def __init__(self, desired_access, creation_disposition, share_mode=0,
+                 security_attributes=None, flags_and_attributes=0, input_nullok=None):
         self.desired_access = desired_access
         self.creation_disposition = creation_disposition
         self.share_mode = share_mode
@@ -182,7 +183,6 @@ class Connection:
 
         self.sock = sock
 
-
     def disconnect(self):
         self.sock.close()
 
@@ -253,9 +253,10 @@ class Connection:
         action = 'test-associate'
         assert identity.associated_id_key is not None, identity.associated_id_key
 
-        message = create_message(action
-                                      , id=identity.associated_name
-                                      , key=binary_to_b64(identity.associated_id_key)
+        message = create_message(
+            action
+            , id=identity.associated_name
+            , key=binary_to_b64(identity.associated_id_key)
         )
         try:
             self.encrypt_message_send_command(identity, action, message)
@@ -314,7 +315,8 @@ class Connection:
 
 
 class Identity:
-    def __init__(self, client_id, public_key=None, private_key=None, id_key=None, associated_name=None, server_public_key=None):
+    def __init__(self, client_id, public_key=None, private_key=None,
+                 id_key=None, associated_name=None, server_public_key=None):
         self.client_id = client_id
         if not public_key:
             assert not private_key
@@ -351,7 +353,7 @@ class Identity:
     def serialize(self):
         binary_data = self.publicKey, self.secretKey, self.associated_id_key, self.serverPublicKey
         text_data = self.associated_name,
-        binary_data  = [binary_to_b64(d) for d in binary_data]
+        binary_data = [binary_to_b64(d) for d in binary_data]
         s = json.dumps(list(binary_data) + list(text_data))
         return s
 

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -191,11 +191,9 @@ class Connection:
         identity.serverPublicKey = server_public_key
 
     def get_database_hash(self, identity):
-        # doesn't ned to be encrypted
         action = 'get-databasehash'
         message = create_message(action)
-        command = create_command(action, message=json.dumps(message))
-        resp_message = self.send_encrypted_command(identity, command)
+        resp_message = self.encrypt_message_send_command(identity, action, message)
         return resp_message['hash']
 
     def associate(self, identity):

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -5,6 +5,7 @@ import platform
 import pysodium
 import socket
 from pathlib import Path
+import win32file
 
 BUFF_SIZE = 1024 * 1024
 DEFAULT_SOCKET_TIMEOUT = 60
@@ -105,6 +106,40 @@ class ProtocolError(Exception):
     pass
 
 
+class WinSock:
+    """ A basic socket wrapper for Windows named pipes """
+    def __init__(self, desired_access, creation_disposition, share_mode=0, security_attributes=None, flags_and_attributes=0, input_nullok=None):
+        self.desired_access = desired_access
+        self.creation_disposition = creation_disposition
+        self.share_mode = share_mode
+        self.security_attributes = security_attributes
+        self.flags_and_attributes = flags_and_attributes
+        self.input_nullok = input_nullok
+        self.handle = None
+
+    def connect(self, address):
+        self.handle = win32file.CreateFile(
+            r'\\.\pipe\%s' % address,
+            self.desired_access,
+            self.share_mode,
+            self.security_attributes,
+            self.creation_disposition,
+            self.flags_and_attributes,
+            self.input_nullok
+        )
+
+    def close(self):
+        if self.handle:
+            self.handle.close()
+
+    def send(self, message: str):
+        win32file.WriteFile(self.handle, message)
+
+    def recvfrom(self, buff_size):
+        response_code, data = win32file.ReadFile(self.handle, buff_size)
+        return data, response_code
+
+
 class Connection:
     def __init__(self):
         # TODO: darwin is untested
@@ -114,7 +149,9 @@ class Connection:
             tmpdir_socket_path = (tmpdir / DEFAULT_SOCKET_NAME)
         xdg_runtime_dir = os.getenv('XDG_RUNTIME_DIR')
 
-        if platform.system() == "Darwin" and tmpdir and tmpdir_socket_path.exists():
+        if platform.system() == "Windows":
+            server_address = Path(os.getenv("TMP")) / DEFAULT_SOCKET_NAME
+        elif platform.system() == "Darwin" and tmpdir and tmpdir_socket_path.exists():
             server_address = tmpdir_socket_path
         elif xdg_runtime_dir:
             server_address = Path(xdg_runtime_dir) / DEFAULT_SOCKET_NAME
@@ -129,10 +166,13 @@ class Connection:
         self.sock = None
 
     def connect(self):
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, BUFF_SIZE)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, BUFF_SIZE)
+        if platform.system() == "Windows":
+            sock = WinSock(win32file.GENERIC_READ | win32file.GENERIC_WRITE, win32file.OPEN_EXISTING)
+        else:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, BUFF_SIZE)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, BUFF_SIZE)
 
         try:
             sock.connect(str(self.server_address))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pysodium',
+        'pywin32'
     ],
     description='Access the KeepassXC Browser API from python',
     url='https://github.com/hrehfeld/python-keepassxc-browser',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.1',
     packages=find_packages(),
     install_requires=[
-        'pysodium',
+        'PyNaCl',
         'pywin32'
     ],
     description='Access the KeepassXC Browser API from python',

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='keepassxc-browser',
-    version='0.1.1',
+    version='0.2.0',
     packages=find_packages(),
     install_requires=[
-        'PyNaCl',
-        'pywin32'
+        'pysodium; platform_system != "Windows"',
+        'PyNaCl; platform_system == "Windows"',
+        'pywin32; platform_system == "Windows"',
     ],
     description='Access the KeepassXC Browser API from python',
     url='https://github.com/hrehfeld/python-keepassxc-browser',

--- a/test.py
+++ b/test.py
@@ -25,8 +25,9 @@ if not c.test_associate(id):
         f.write(data)
     del data
 
-c.create_password(id)
-c.set_login(id, url='https://python-test123', login='test-user', password='test-password', entry_id=None, submit_url=None)
-c.get_logins(id, url='https://python-test123')
+login, password = c.create_password(id)
+url = 'https://python-test123'
+c.set_login(id, url=url, login='test-user', password=password, entry_id=None, submit_url=None)
+c.get_logins(id, url=url)
 # c.lock_database(id)
 c.disconnect()


### PR DESCRIPTION
Since `socket.AF_UNIX` is not supported on windows, I've made some changes to make this work with named pipes as well.

A draw back is that I didn't figure out how to install libsodium on windows to make it work with pysodium. This is why I've switched to PyNaCl on windows for now.

Tasks:
- [x] test on windows 7
- [ ]  test on windows 10
- [ ] test on linux
- [ ] test on mac
- [ ] decide wither PyNaCl is a good alternative to pysodium