### PR TITLE
Make ProtocolError easier to use

### DIFF
--- a/keepassxc_browser/__init__.py
+++ b/keepassxc_browser/__init__.py
@@ -1,1 +1,2 @@
 from .protocol import Connection, Identity
+from .exceptions import ProtocolError

--- a/keepassxc_browser/exceptions.py
+++ b/keepassxc_browser/exceptions.py
@@ -1,0 +1,2 @@
+class ProtocolError(Exception):
+    pass

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -1,3 +1,4 @@
+from .exceptions import ProtocolError
 from base64 import b64decode, b64encode
 import json
 import os.path
@@ -99,10 +100,6 @@ def create_encrypted_command(crypto, action, message):
         , message=binary_to_b64(crypto.encrypt_message(message, nonce))
     )
     return command, nonce
-
-
-class ProtocolError(Exception):
-    pass
 
 
 class Connection:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keepassxc-browser',
-    version='0.1.1',
+    version='0.1.2',
     packages=find_packages(),
     install_requires=[
         'pysodium',

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-from keepassxc_browser import Connection, Identity
+from keepassxc_browser import Connection, Identity, ProtocolError
 from pathlib import Path
 
 
@@ -15,7 +15,11 @@ else:
 c = Connection()
 c.connect()
 c.change_public_keys(id)
-c.get_database_hash(id)
+try:
+    c.get_database_hash(id)
+except ProtocolError as ex:
+    print(ex)
+    exit(1)
 
 if not c.test_associate(id):
     associated_name = c.associate(id)


### PR DESCRIPTION
#5 indicates there is confusion about how to use ProtocolError. This PR makes `__init__.py` import the exception along with the protocol, and in `test.py` it is used in a `try ... catch` around the `get_database_hash()` method as an example

Since this could potentially break any scripts people may have written by now, I also bumped the version number 