### PR TITLE
Feat/groups

### DIFF
--- a/example.py
+++ b/example.py
@@ -30,6 +30,11 @@ def main():
         del data
 
     c.create_password(id)
+    groups = c.get_database_groups(id)
+    root = groups[0] # {name: 'AAAA', uuid: 'BBBB', children: [...]}
+    foo = c.create_database_group(id, 'foo')
+    assert foo['uuid'] == c.find_group_uuid(id, 'foo')
+    
     c.set_login(id, url='https://python-test123', login='test-user', password='test-password', entry_id=None, submit_url=None)
     c.get_logins(id, url='https://python-test123')
     # c.lock_database(id)

--- a/example.py
+++ b/example.py
@@ -35,7 +35,13 @@ def main():
     foo = c.create_database_group(id, 'foo')
     assert foo['uuid'] == c.find_group_uuid(id, 'foo')
     
-    c.set_login(id, url='https://python-test123', login='test-user', password='test-password', entry_id=None, submit_url=None)
+    c.set_login(id, 
+                url='https://python-test123', 
+                login='test-user', 
+                password='test-password', 
+                group_uuid=foo['uuid'], 
+                submit_url=None)
+    
     c.get_logins(id, url='https://python-test123')
     # c.lock_database(id)
     c.disconnect()

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -308,9 +308,6 @@ class Connection:
                 return main_group['uuid']
 
             for db_group in main_group['children']:
-                if db_group['name'] == group_name:
-                    return db_group['uuid']
-
                 child_group = topdown_search(db_group)
 
                 if child_group:

--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -264,7 +264,6 @@ class Connection:
                 login=None, 
                 password=None, 
                 submit_url=None,
-                group=None,
                 group_uuid=None,
                 uuid=None):
         action = 'set-login'
@@ -273,6 +272,13 @@ class Connection:
             , id=identity.associated_name
             , url=url
         )
+        
+        # keepassXC browser strange behaviour, to apply to a group by uuid the group 
+        # variable must not be an empty string, so... 
+        group = None
+        if group_uuid:
+            group = 'baz'
+
         for k in 'login password submit_url group group_uuid uuid'.split():
             v = locals()[k]
             if v is not None:


### PR DESCRIPTION
Hi human! First things first. Thank you for this repo, it really helped me out.

The first thing I needed was to apply entries to some specific group. After a quick research I found this [guideline](https://github.com/varjolintu/keepassxc-browser/blob/master/keepassxc-protocol.md), which shows the actions available. So I created functions related to groups, such as create, list and find by name. It worked great with your API obviously, but I still needed a way to create entries for a group and that is the funny part. Getting back to the protocol guidelines, I first stated:
- `entry_id` parameter on `Connection:set_login()` does nothing, in fact we are not able to specify a title for the entry, keepassXC limit (it will always get the host from the url, probably closes #11 )
- `group` and `group_uuid` parameters should be added, and it merges with my group functions

I later discovered that something was not right with `group` and `group_uuid` parameters, it only worked when I specified a group uuid with any group and I could not believe it was that so I checked the source [here](https://github.com/keepassxreboot/keepassxc/blob/8dbd5b11eb43c274b346d1ad69441082a5c3c029/src/browser/BrowserService.cpp#L483). It makes no sense to me, look I love keepassXC but I can not figure out why this, maybe just a bad day. Anyway I added to the code a "fix" to this, where the only way to specify a group is by it's uuid.

I think they should came up with a fix to this, maybe I open an issue. Can you help me with this giving another point of view?

Well I hope you have time to read this, you can get in touch by mail. Out 