### PR TITLE
Add Windows support II

### DIFF
--- a/keepassxc_browser/__init__.py
+++ b/keepassxc_browser/__init__.py
@@ -1,4 +1,6 @@
 from .exceptions import ProtocolError
 from .protocol import Connection, Identity
+from .connection_posix import DefaultSock
+from .connection_win import WinSock
 
 __all__ = ["ProtocolError", "Connection", "Identity"]

--- a/keepassxc_browser/connection_posix.py
+++ b/keepassxc_browser/connection_posix.py
@@ -2,10 +2,9 @@ import socket
 
 
 class DefaultSock:
-    """ A basic socket wrapper for Windows named pipes """
 
     def __init__(self, timeout, buff_size):
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.settimeout(timeout)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, buff_size)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buff_size)
@@ -22,7 +21,7 @@ class DefaultSock:
     def close(self):
         self.sock.close()
 
-    def send(self, message: str):
+    def send(self, message):
         self.sock.send(message)
 
     def recvfrom(self, buff_size):

--- a/keepassxc_browser/connection_posix.py
+++ b/keepassxc_browser/connection_posix.py
@@ -1,0 +1,29 @@
+import socket
+
+
+class DefaultSock:
+    """ A basic socket wrapper for Windows named pipes """
+
+    def __init__(self, timeout, buff_size):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.settimeout(timeout)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, buff_size)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buff_size)
+
+    def connect(self, address):
+        try:
+            self.sock.connect(address)
+        except socket.error:
+            self.sock.close()
+            raise Exception(
+                "Could not connect to {addr}".format(addr=address)
+            )
+
+    def close(self):
+        self.sock.close()
+
+    def send(self, message: str):
+        self.sock.send(message)
+
+    def recvfrom(self, buff_size):
+        return self.sock.recvfrom(buff_size)

--- a/keepassxc_browser/connection_win.py
+++ b/keepassxc_browser/connection_win.py
@@ -34,7 +34,7 @@ class WinSock:
         if self.handle:
             self.handle.close()
 
-    def send(self, message: str):
+    def send(self, message):
         win32file.WriteFile(self.handle, message)
 
     def recvfrom(self, buff_size):

--- a/keepassxc_browser/connection_win.py
+++ b/keepassxc_browser/connection_win.py
@@ -1,0 +1,42 @@
+import win32file
+
+
+class WinSock:
+    """ A basic socket wrapper for Windows named pipes """
+
+    def __init__(self, desired_access, creation_disposition, share_mode=0,
+                 security_attributes=None, flags_and_attributes=0, input_nullok=None):
+        self.desired_access = desired_access
+        self.creation_disposition = creation_disposition
+        self.share_mode = share_mode
+        self.security_attributes = security_attributes
+        self.flags_and_attributes = flags_and_attributes
+        self.input_nullok = input_nullok
+        self.handle = None
+
+    def connect(self, address):
+        try:
+            self.handle = win32file.CreateFile(
+                r'\\.\pipe\%s' % address,
+                self.desired_access,
+                self.share_mode,
+                self.security_attributes,
+                self.creation_disposition,
+                self.flags_and_attributes,
+                self.input_nullok
+            )
+        except Exception as e:
+            raise Exception(
+                "Could not connect to pipe {addr}".format(addr=address), e
+            )
+
+    def close(self):
+        if self.handle:
+            self.handle.close()
+
+    def send(self, message: str):
+        win32file.WriteFile(self.handle, message)
+
+    def recvfrom(self, buff_size):
+        response_code, data = win32file.ReadFile(self.handle, buff_size)
+        return data, response_code

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ setup(
     name='keepassxc-browser',
     version='0.1.5',
     packages=find_packages(),
-    install_requires=['pysodium'],
+    install_requires=[
+        'pysodium',
+        'pywin32; platform_system == "Windows"'
+    ],
     description='Access the KeepassXC Browser API from python',
     url='https://github.com/hrehfeld/python-keepassxc-browser',
     author='Hauke Rehfeld',


### PR DESCRIPTION
Used the input of https://github.com/hrehfeld/python-keepassxc-browser/pull/4 and tried to address the review findings.

- Reduced number of platform specific branches
- kept pysodium, windows user needs to place the libsodium.dll in c:\windows\system32

There is also the option to use [csodium](https://github.com/ereOn/csodium) or PyNaCl but i had issues on my side. But i think it's ok the user has to get the dependency by himself.

For Windows 10 it works, can not test for Linux or Mac.