### PR TITLE
Correctly increment nonces

### DIFF
--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -50,8 +50,7 @@ def increment_nonce(nonce):
     c_state = 1
     for i, x in enumerate(next_nonce):
         c_state += x
-        c_state %= 256
-        next_nonce[i] = c_state
+        next_nonce[i] = c_state % 256
         c_state >>= 8
 
     return bytes(next_nonce)


### PR DESCRIPTION
The previous implementation of `increment_nonce()` does not handle
carries correctly. For example,

    nonce = b'\xff\x00'
    assert increment_nonce(nonce) == b'\x00\x01'  # fails!

Here I don't use `pysodium.sodium_increment()`, which is added in
2019 [1], as that function updates the nonce in-place, while
keepassxc-browser also needs the original nonce (ex: `create_nonces()`).

See also the implementation in the last libsodium version
https://github.com/jedisct1/libsodium/blob/1.0.18/src/libsodium/sodium/utils.c#L244-L289

[1] https://github.com/stef/pysodium/commit/e0cbdbe38f1ff7388bbd32d3e8eb60a143ff359d