### PR TITLE
Fix wait_for_unlock()

### DIFF
--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -298,7 +298,7 @@ class Connection:
         """
         while True:
             try:
-                action = json.loads(self.connection.recv(BUFF_SIZE).decode())['action']
+                action = json.loads(self.connection.recvfrom(BUFF_SIZE)[0].decode())['action']
                 if action == "database-unlocked":
                     break
             except socket.timeout:


### PR DESCRIPTION
This change fixes an issue introduced by
6fcb9b69fc184c6327c16dcb5e53b471ce285f5c, where a connection is no
longer a socket but a wrapper. For example,
```
$ cat example2.py

from pathlib import Path

from keepassxc_browser import Connection, Identity, ProtocolError

client_id = 'python-keepassxc-browser'

state_file = Path('.assoc')
if state_file.exists():
    with state_file.open('r') as f:
        data = f.read()
    id = Identity.unserialize(client_id, data)
else:
    id = Identity(client_id)

c = Connection()
c.connect()
c.change_public_keys(id)
try:
    db_hash = c.get_database_hash(id)
except ProtocolError as ex:
    print(ex)
    c.wait_for_unlock()
print(db_hash)

c.disconnect()

$ python example2.py
資料庫未開啟
Traceback (most recent call last):
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/example2.py", line 19, in <module>
    db_hash = c.get_database_hash(id)
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/keepassxc_browser/protocol.py", line 189, in get_database_hash
    resp_message = self.encrypt_message_send_command(identity, action, message)
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/keepassxc_browser/protocol.py", line 172, in encrypt_message_send_command
    return self.send_encrypted_command(identity, command, nonce)
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/keepassxc_browser/protocol.py", line 166, in send_encrypted_command
    resp = self.send_command(identity, command, nonce, next_nonce)
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/keepassxc_browser/protocol.py", line 160, in send_command
    raise ProtocolError(resp['error'])
keepassxc_browser.exceptions.ProtocolError: 資料庫未開啟

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/example2.py", line 22, in <module>
    c.wait_for_unlock()
  File "/home/yen/var/local/Computer/keepassxc/python-keepassxc-browser/keepassxc_browser/protocol.py", line 300, in wait_for_unlock
    action = json.loads(self.connection.recv(BUFF_SIZE).decode())['action']
AttributeError: 'DefaultSock' object has no attribute 'recv'
```