### PR TITLE
fix(protocol): set_login should not restrict url

### DIFF
--- a/keepassxc_browser/protocol.py
+++ b/keepassxc_browser/protocol.py
@@ -257,8 +257,6 @@ class Connection:
     def set_login(
         self, identity, url, login=None, password=None, entry_id=None, submit_url=None
     ):
-        if not (url.startswith('mailto:') or url.startswith('https:')):
-            raise Exception('Url needs to start with "mailto:" or "https:"')
         action = 'set-login'
         message = create_message(action, id=identity.associated_name, url=url)
 


### PR DESCRIPTION
Currently you're forced to supply a url that startswith `mailto:` or `https:` for set_login.

Any value is acceptable in keepass, there is no need to limit it in this way.